### PR TITLE
newestとpopularの切り替えの実装

### DIFF
--- a/app/assets/javascripts/top.js
+++ b/app/assets/javascripts/top.js
@@ -1,0 +1,8 @@
+window.addEventListener("load", function() {
+  var $list = $("li").attr("role", "presentation");
+  $list.on("click", function() {
+    $list.remove("active");
+    $(this).addClass("active");
+  });
+});
+

--- a/app/controllers/prototypes/newest_controller.rb
+++ b/app/controllers/prototypes/newest_controller.rb
@@ -1,0 +1,6 @@
+class Prototypes::NewestController < ApplicationController
+  def index
+    @prototypes = Prototype.order('created_at DESC').page(params[:page])
+    render 'top/index'
+  end
+end

--- a/app/controllers/prototypes/popular_controller.rb
+++ b/app/controllers/prototypes/popular_controller.rb
@@ -1,0 +1,6 @@
+class Prototypes::PopularController < ApplicationController
+  def index
+    @prototypes = Prototype.order('likes_count DESC').page(params[:page])
+    render "top/index"
+  end
+end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -13,7 +13,7 @@ class Prototype < ActiveRecord::Base
   #fields_for(formのネスト)
   accepts_nested_attributes_for :thumbnails
 
-  #like_userというメソッドはそのユーザが、アクセスしている投稿にlikeをしているかどうかというものを判定するものです。
+  #liked_by?というメソッドはそのユーザが、アクセスしている投稿にlikeをしているかどうかというものを判定するものです。
   def liked_by?(user)
     likes.exists?(user_id: user.id)
   end

--- a/app/views/top/index.html.haml
+++ b/app/views/top/index.html.haml
@@ -6,9 +6,9 @@
     .row
       %ul.nav.nav-pills.col-lg-11
         %li.active{:role => "presentation"}
-          = link_to "Popular PROTO", root_path
+          = link_to "Popular PROTO", prototypes_popular_index_path #if request.path.include?("popular")
         %li{:role => "presentation"}
-          = link_to "Newest PROTO", root_path
+          = link_to "Newest PROTO", prototypes_newest_index_path #if request.path.include?("newest")
       = link_to "View Tags", root_path, class: "btn btn-default col-lg-1"
 .container.proto-list
   .row

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,10 +2,14 @@ Rails.application.routes.draw do
 
   root 'top#index'
   devise_for :users
-  resources :prototypes
+
   namespace :prototypes do #rails g controller prototypes/users
     resources :users, only: [:edit, :update, :show]
+    resources :newest, only: [:index]
+    resources :popular, only: [:index]
   end
+
+  resources :prototypes
   resources :tags, only: [:index, :show]
   resources :comments, only: [:new, :create]
   resources :likes, only: [:create, :destroy]


### PR DESCRIPTION
# WHAT

routingのnamespace :prototypesの中にnewestとpopularを追加し、各indexアクションの各インスタンス変数(@prototypes)ごとに持たせるオブジェクトを分け、view（index）の内容が切り替わるように実装。
# REMARKS

コメントアウトは自分用に残したいので悪しからず。
